### PR TITLE
Add `SameSite=Lax` to cookie for removing browser warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ colorMode: {
   cookie: {
     key: 'nuxt-color-mode',
     options: {
-      path: nuxt.options.router.base // https://nuxtjs.org/api/configuration-router#base
+      path: nuxt.options.router.base, // https://nuxtjs.org/api/configuration-router#base
+      sameSite: 'lax' // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
     }
   }
 }
@@ -110,7 +111,7 @@ colorMode: {
 
 Notes:
 - `'system'` is a special value, it will automatically detect the color mode based on the system preferences (see [prefers-color-mode spec](https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-mode)). The value injected will be either `'light'` or `'dark'`. If `no-preference` is detected or the browser does not handle color-mode, it will set the `fallback` value.
-- `cookie` are the options where to store the chosen color mode (to make it work universally), the `cookie.options` are available on the [cookie serialize options](https://www.npmjs.com/package/cookie#options-1) documentation.
+- `cookie` are the options where to store the chosen color mode (to make it work universally), the `cookie.options` are available on the [cookie serialize options](https://www.npmjs.com/package/cookie#options-1) documentation. Each option will recursively overwrite the default property (by using [defu](https://github.com/nuxt-contrib/defu)).
 
 ## Caveats
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -14,7 +14,8 @@ export default async function (moduleOptions) {
     cookie: {
       key: 'nuxt-color-mode',
       options: {
-        path: this.options.router.base
+        path: this.options.router.base,
+        sameSite: 'lax'
       }
     }
   }


### PR DESCRIPTION
This removes the warning that browsers have started writing out in the console.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-5.2

I set the SameSite option to 'Lax', but I'm not sure this is the best option for color-mode-module. If anyone knows the situation better with adding the SameSite option, or setting it to anything else, please shine some light on the issue.

This doesn't need to be a color-mode-module default, as the users can themselves set this option too. Though I'd argue to clarify it further in the documentation then.