### PR TITLE
fix(type-defs): add types reference to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "types"
   ],
   "main": "lib/module.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "dev": "nuxt example",
     "build": "rollup -c",


### PR DESCRIPTION
Add `types` field to `package.json` so TS picks the type definitions up correctly.