### PR TITLE
fix(type-defs): make all options optional

### DIFF
--- a/types/color-mode.d.ts
+++ b/types/color-mode.d.ts
@@ -2,35 +2,35 @@ export interface ColorModeOptions {
   /**
    * Default: `system`
    */
-  preference?: string, // default value of $colorMode.preference
+  preference: string, // default value of $colorMode.preference
   /**
    * Default: `light`
    */
-  fallback?: string, // fallback value if not system preference found
+  fallback: string, // fallback value if not system preference found
   /**
    * Default: `nuxt-color-mode-script`
    */
-  hid?: string,
+  hid: string,
   /**
    * Default: `__NUXT_COLOR_MODE__`
    */
-  globalName?: string,
+  globalName: string,
   /**
    * Default: `ColorScheme`
    */
-  componentName?: string,
+  componentName: string,
   /**
    * Default: ''
    */
-  classPrefix?: string,
+  classPrefix: string,
   /**
    * Default: '-mode'
    */
-  classSuffix?: string,
+  classSuffix: string,
   /**
    * Default: 'nuxt-color-mode'
    */
-  storageKey?: string
+  storageKey: string
 }
 
 export interface ColorModeInstance {
@@ -39,3 +39,5 @@ export interface ColorModeInstance {
   unknown: boolean,
   forced: boolean
 }
+
+export type ColorModeConfig = Partial<ColorModeOptions>;

--- a/types/color-mode.d.ts
+++ b/types/color-mode.d.ts
@@ -2,35 +2,35 @@ export interface ColorModeOptions {
   /**
    * Default: `system`
    */
-  preference: string, // default value of $colorMode.preference
+  preference?: string, // default value of $colorMode.preference
   /**
    * Default: `light`
    */
-  fallback: string, // fallback value if not system preference found
+  fallback?: string, // fallback value if not system preference found
   /**
    * Default: `nuxt-color-mode-script`
    */
-  hid: string,
+  hid?: string,
   /**
    * Default: `__NUXT_COLOR_MODE__`
    */
-  globalName: string,
+  globalName?: string,
   /**
    * Default: `ColorScheme`
    */
-  componentName: string,
+  componentName?: string,
   /**
    * Default: ''
    */
-  classPrefix: string,
+  classPrefix?: string,
   /**
    * Default: '-mode'
    */
-  classSuffix: string,
+  classSuffix?: string,
   /**
    * Default: 'nuxt-color-mode'
    */
-  storageKey: string
+  storageKey?: string
 }
 
 export interface ColorModeInstance {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
-import { ColorModeOptions, ColorModeInstance } from "./color-mode";
+import { ColorModeConfig, ColorModeInstance } from "./color-mode";
 
 declare module '@nuxt/types/config/index' {
   interface NuxtOptions {
-    colorMode: ColorModeOptions
+    colorMode: ColorModeConfig
   }
 }
 


### PR DESCRIPTION
When using the module with a typed `nuxt.config.ts`, TypeScript requires all properties of the options object to be set.
They don't have to, because the defaults will be used if they are not set.