### PR TITLE
fix(type-defs): make interface ColorModeInstance extend Vue

### DIFF
--- a/types/color-mode.d.ts
+++ b/types/color-mode.d.ts
@@ -1,3 +1,5 @@
+import Vue from 'vue'
+
 export interface ColorModeOptions {
   /**
    * Default: `system`
@@ -33,7 +35,7 @@ export interface ColorModeOptions {
   storageKey: string
 }
 
-export interface ColorModeInstance {
+export interface ColorModeInstance extends Vue {
   preference: string,
   value: string,
   unknown: boolean,


### PR DESCRIPTION
When using TypeScript and trying to create a watcher on the `value` property, the TypeScript compiler complains with:

`TS2339: Property '$watch' does not exist on type 'ColorModeInstance'.`

**Code example:**

```js
import { Plugin } from '@nuxt/types'

const colorThemePlugin: Plugin = ({ $colorMode }) => {
  $colorMode.$watch('value', (val: string) => {
    console.log(val)
  })
}

export default colorThemePlugin
```

Making the interface `ColorModeInstance` extend `Vue`, the compiler does not complain.


