### PR TITLE
fix: types compatible with nuxt-property-decorator

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,3 +24,15 @@ declare module 'vue/types/vue' {
     $colorMode: ColorModeInstance
   }
 }
+
+declare module 'vue/types/options' {
+  interface ComponentOptions<V extends Vue> {
+    /**
+     * Forces a color mode for current page
+     * @see https://color-mode.nuxtjs.org/#force-a-color-mode
+     */
+    colorMode?: string
+  }
+}
+
+


### PR DESCRIPTION
No more type errors for forced color mode on nuxt-property-decorator
```ts
import { Component } from 'nuxt-property-decorator'
import Vue from 'vue'
@Component({
  colorMode: 'light',
  ...
})
export default class LightModeForcedPage extends Vue {
 ...
}
```

Given error before this fix:
```
 Overload 1 of 2, '(options: ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>> & ThisType<...>): <VC extends VueClass<...>>(target: VC) => VC', gave the following error.
    Argument of type '{ colorMode: string; layout: string; components: { ValidationObserver: ExtendedVue<Vue & { $_veeObserver: VeeObserver; $vnode: VNodeWithVeeContext; }, { ...; }, { ...; }, unknown, { ...; }>; ValidationProvider: ExtendedVue<...>; DatePicker: any; }; }' is not assignable to parameter of type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>> & ThisType<...>'.
      Object literal may only specify known properties, and 'colorMode' does not exist in type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Record<string, any>>, Record<...>> & ThisType<...>'.
```