### PR TITLE
fix: spa mode issue

### DIFF
--- a/lib/templates/plugin.client.js
+++ b/lib/templates/plugin.client.js
@@ -8,7 +8,7 @@ const colorMode = window['<%= options.globalName %>']
 const getForcedColorMode = route => route.matched[0] && route.matched[0].components.default.options.colorMode
 
 export default function (ctx, inject) {
-  let data = ctx.nuxtState.colorMode
+  let data = ctx.nuxtState ? ctx.nuxtState.colorMode : null
   // For SPA mode or fallback
   if (!data) {
     data = {


### PR DESCRIPTION
Our team was having issues with this module with our project (which is in 'spa' mode). The changed line was giving an error due to the fact that nuxtState does not exist on the context in 'spa' mode.