### PR TITLE
refactor: hard code script in app template

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -2,6 +2,8 @@ import { resolve } from 'path'
 import { promises as fsp } from 'fs'
 import defu from 'defu'
 import template from 'lodash.template'
+import { stringifyTag } from 'unmeta'
+
 import { addTemplates } from './utils'
 
 export default async function (moduleOptions) {
@@ -24,23 +26,39 @@ export default async function (moduleOptions) {
   // Add script to head to detect user or system preference before loading Nuxt (for SSR)
   const scriptPath = resolve(__dirname, 'script.min.js')
   const scriptT = await fsp.readFile(scriptPath, 'utf-8')
-  const script = template(scriptT)({ options })
 
-  options.script = script
-
-  this.nuxt.hook('vue-renderer:spa:prepareContext', ({ head }) => {
-    const script = {
-      hid: options.hid,
-      innerHTML: options.script,
-      pbody: true
-    }
-
-    head.script.push(script)
-
-    const serializeProp = '__dangerouslyDisableSanitizersByTagID'
-    head[serializeProp] = head[serializeProp] || {}
-    head[serializeProp][options.hid] = ['innerHTML']
+  const script = stringifyTag({
+    tag: 'script',
+    content: template(scriptT)({ options }).trim()
   })
+
+  // Support for @nuxt/nitro
+  this.nuxt.hook('nitro:template', (tmpl) => {
+    tmpl.contents = tmpl.contents.replace(/<body[^>]*>/, r => r + '\n    ' + script)
+  })
+
+  // In dev and static generation mode, the renderer hooks inject the script
+  if (this.nuxt.options.dev || this.nuxt.options.target === 'static') {
+    this.nuxt.hook('vue-renderer:spa:templateParams', (templateParams) => {
+      templateParams.APP = script + templateParams.APP
+    })
+    this.nuxt.hook('vue-renderer:ssr:templateParams', (templateParams) => {
+      templateParams.APP = script + templateParams.APP
+    })
+  } else {
+    // In build + start mode, the template files are edited directly
+    this.nuxt.hook('build:done', async () => {
+      const templates = ['index.ssr.html', 'index.spa.html']
+      for (const template of templates) {
+        try {
+          const templatePath = resolve(this.options.buildDir, 'dist/server', template)
+          let contents = await fsp.readFile(templatePath, 'utf-8')
+          contents = contents.replace(/<body[^>]*>/, r => r + '\n    ' + script)
+          await fsp.writeFile(templatePath, contents)
+        } catch {}
+      }
+    })
+  }
 
   // Add all templates
   const templatesDir = resolve(__dirname, 'templates')

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-import { resolve } from 'path'
+import { join, resolve } from 'path'
 import { promises as fsp } from 'fs'
 import defu from 'defu'
 import template from 'lodash.template'
@@ -32,12 +32,7 @@ export default async function (moduleOptions) {
     content: template(scriptT)({ options }).trim()
   })
 
-  // Support for @nuxt/nitro
-  this.nuxt.hook('nitro:template', (tmpl) => {
-    tmpl.contents = tmpl.contents.replace(/<body[^>]*>/, r => r + '\n    ' + script)
-  })
-
-  // In dev and static generation mode, the renderer hooks inject the script
+  // In dev and static generation modes, renderer hooks inject the script into rendered HTML
   if (this.nuxt.options.dev || this.nuxt.options.target === 'static') {
     this.nuxt.hook('vue-renderer:spa:templateParams', (templateParams) => {
       templateParams.APP = script + templateParams.APP
@@ -56,6 +51,23 @@ export default async function (moduleOptions) {
           contents = contents.replace(/<body[^>]*>/, r => r + '\n    ' + script)
           await fsp.writeFile(templatePath, contents)
         } catch {}
+      }
+    })
+
+    // Support for @nuxt/nitro
+    this.nuxt.hook('nitro:template', (tmpl) => {
+      tmpl.contents = tmpl.contents.replace(/<body[^>]*>/, r => r + '\n    ' + script)
+    })
+  }
+
+  // In dev mode we also inject full script via webpack entrypoint for storybook compatibility
+  if (this.nuxt.options.dev) {
+    const { dst } = this.addTemplate({ src: resolve(__dirname, 'script.js'), fileName: join('color-mode', 'script.js'), options })
+    this.nuxt.hook('webpack:config', (configs) => {
+      for (const config of configs) {
+        if (config.name !== 'server') {
+          config.entry.app.unshift(resolve(this.nuxt.options.buildDir, dst))
+        }
       }
     })
   }

--- a/lib/templates/plugin.server.js
+++ b/lib/templates/plugin.server.js
@@ -3,32 +3,7 @@ import colorSchemeComponent from './color-scheme'
 
 Vue.component('<%= options.componentName %>', colorSchemeComponent)
 
-const script = {
-  hid: '<%= options.hid %>',
-  innerHTML: `<%= options.script %>`,
-  pbody: true
-}
-const addScript = (head) => {
-  head.script = head.script || []
-  head.script.push(script)
-  const serializeProp = '__dangerouslyDisableSanitizersByTagID'
-  head[serializeProp] = head[serializeProp] || {}
-  head[serializeProp]['<%= options.hid %>'] = ['innerHTML']
-}
-
-
 export default function (ctx, inject) {
-  if (typeof ctx.app.head === 'function') {
-    const originalHead = ctx.app.head
-    ctx.app.head = function () {
-      const head = originalHead.call(this) || {}
-      addScript(head)
-      return head
-    }
-  } else {
-    addScript(ctx.app.head)
-  }
-
   const preference = '<%= options.preference %>'
 
   const colorMode = {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "defu": "^5.0.0",
-    "lodash.template": "^4.5.0"
+    "lodash.template": "^4.5.0",
+    "unmeta": "^0.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11812,6 +11812,11 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unmeta@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/unmeta/-/unmeta-0.0.2.tgz#e68dc1c1bb15b232a8de687e097cafa7c2b782b9"
+  integrity sha512-l3+JdipEyzv3xMRnrH5wPX7F7zxV1FgwYLajMJsF5TgMYvCTKRM3l+zoxK+Zyc9BFMsVLdFB9Z0ieqJlyaY2fg==
+
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
This is yet another refactor, this time designed to remove any runtime need for generating the color-mode script. There's not yet a standardised way to engage with the document template directly, but this is an attempt to fully cover all targets. Perhaps in future we could consider a `@nuxt/kit` helper along these lines.

## Local tests
[note, ci tests _should_ pass when #96 is merged]

| SSR     | Target | Commands                     | Test |
| ------- | ------ | ---------------------------- | ---- |
| false   | server | dev, generate, build + start | ✅    |
| false   | static | dev, generate                | ✅    |
| true    | server | dev, generate, build + start | ✅    |
| true    | static | dev, generate                | ✅    |
| [nitro] | server | dev, build + start           | ✅    |
| [nitro] | static | dev, generate                | ✅    |

## Workarounds
- [x] `@nuxtjs/storybook` and other solutions extending the Nuxt webpack config will work, even if client-only as (in dev mode) the color-mode script is added to the nuxt entrypoint - thoughts welcome on the approach...