### PR TITLE
fix: rename useMeta to useHead

### DIFF
--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -2,7 +2,7 @@ import { defineNuxtPlugin, isVue2, isVue3 } from '#app'
 import { reactive } from 'vue'
 
 import type { ColorModeInstance } from './types'
-import { useMeta, useState, useRouter } from '#imports'
+import { useHead, useState, useRouter } from '#imports'
 import { preference, hid, script } from '#color-mode-options'
 
 const addScript = (head) => {
@@ -44,7 +44,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   if (isVue3) {
-    useMeta({
+    useHead({
       htmlAttrs,
       script: [{ children: script }]
     })


### PR DESCRIPTION
The `useMeta` property has been renamed to `useHead`. Without this change the module would be broken with the latest framework version.

Regarding to this: https://github.com/nuxt/framework/pull/4066
