### PR TITLE
fix(composable): use `#app` instead of `#imports` to avoid circular reference

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,5 +1,5 @@
 import type { ColorModeInstance } from './types'
-import { useState } from '#imports'
+import { useState } from '#app'
 
 export const useColorMode = () => {
   return useState('color-mode').value as ColorModeInstance


### PR DESCRIPTION
While `composables.ts` are registered for auto import, it references `#imports` which contains all auto imports, making it circular.

After https://github.com/unjs/unimport/pull/85 it might be resolved, but I think it's still better to be explicit and avoid this usage from the beginning.