### PR TITLE
fix: prioritize config preference over stored value when not 'system'

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -10,11 +10,11 @@
 
   const storedPreference = getStorageValue('<%= options.storage %>', '<%= options.storageKey %>')
   const configPreference = '<%= options.preference %>'
-  
+
   // Use config preference if it's not 'system', otherwise use stored preference or fallback to config
   const preference = configPreference !== 'system' ? configPreference : (storedPreference || configPreference)
   let value = preference === 'system' ? getColorScheme() : preference
-  
+
   // Applied forced color mode
   const forcedColorMode = de.getAttribute('data-color-mode-forced')
   if (forcedColorMode) {


### PR DESCRIPTION
This fixes an issue where explicitly configured color mode preferences (like preference: 'light') would be overridden by previously stored values from localStorage/cookies.

When a user sets preference to a specific mode (not 'system'), it should take precedence over any stored preferences from previous sessions.

Fixes: Color mode preference not respected when switching between projects

### 🔗 Linked issue
Fixes #318
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)