### PR TITLE
fix: stub helper utility with no-ops in test mode

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -12,20 +12,24 @@ type Helper = {
   removeColorScheme: (className: string) => void
 }
 
+let helper = window[globalName] as unknown as Helper
+
 // Initialise to object with defaults and no-ops to avoid hard error when hydrating app in test mode
-const helper: Helper = (window[globalName] as unknown as Helper || {
-  preference: 'light',
-  value: 'light',
-  getColorScheme: () => 'light',
-  addColorScheme: () => {},
-  removeColorScheme: () => {},
-})
+if (import.meta.test && !helper) {
+  helper = {
+    preference: 'light',
+    value: 'light',
+    getColorScheme: () => 'light',
+    addColorScheme: () => {},
+    removeColorScheme: () => {},
+  }
+}
 
 export default defineNuxtPlugin((nuxtApp) => {
   const colorMode = useState<ColorModeInstance>('color-mode', () => reactive({
     // For SPA mode or fallback
-    preference: helper?.preference,
-    value: helper?.value,
+    preference: helper.preference,
+    value: helper.value,
     unknown: false,
     forced: false,
   })).value
@@ -64,7 +68,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       }
       colorMode.forced = false
       colorMode.value = colorMode.preference === 'system'
-        ? helper?.getColorScheme()
+        ? helper.getColorScheme()
         : colorMode.preference
     }
   })
@@ -79,7 +83,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     darkWatcher = window.matchMedia('(prefers-color-scheme: dark)')
     darkWatcher.addEventListener('change', () => {
       if (!colorMode.forced && colorMode.preference === 'system') {
-        colorMode.value = helper?.getColorScheme()
+        colorMode.value = helper.getColorScheme()
       }
     })
   }
@@ -103,7 +107,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       return
     }
     if (preference === 'system') {
-      colorMode.value = helper?.getColorScheme()
+      colorMode.value = helper.getColorScheme()
       watchMedia()
     }
     else {
@@ -122,8 +126,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       style.appendChild(document.createTextNode('*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}'))
       window!.document.head.appendChild(style)
     }
-    helper?.removeColorScheme(oldValue)
-    helper?.addColorScheme(newValue)
+    helper.removeColorScheme(oldValue)
+    helper.addColorScheme(newValue)
     if (disableTransition) {
       // Calling getComputedStyle forces the browser to redraw
 
@@ -138,8 +142,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   nuxtApp.hook('app:mounted', () => {
     if (colorMode.unknown) {
-      colorMode.preference = helper?.preference
-      colorMode.value = helper?.value
+      colorMode.preference = helper.preference
+      colorMode.value = helper.value
       colorMode.unknown = false
     }
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #228 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The helper method is initialized as an empty object as a fallback when the helper does not exist on the window object. Later in the code, it's expected that the helper has working methods. This seems to work fine when running a Nuxt app, but not in Vitest.

In this fix I add no-ops and optional chaining to prevent `x is not defined on y` errors.