### PR TITLE
fix: avoid optional chaining

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -97,6 +97,10 @@ function getCookie(name) {
   const value = '; ' + window.document.cookie
   const parts = value.split('; ' + name + '=')
   if (parts.length === 2) {
-    return parts.pop()?.split(';').shift()
+    const part = parts.pop()
+    if (!part) {
+      return null
+    }
+    return part.split(';').shift()
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves: #343

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Replaces ES2020 optional chaining (?.) with an ES5-compatible.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
