### PR TITLE
fix: client crash when disabled cookies and storage

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -139,8 +139,9 @@ function setPreferenceToStorage(preference: string) {
       }
       try {
         window.document.cookie = cookieString
-      } catch (e: unknown) {
-        // console.log(`Problem setting cookie. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+      }
+      catch {
+        // Ignore cookie write errors; storage may be blocked.
       }
     }
     else {
@@ -152,15 +153,17 @@ function setPreferenceToStorage(preference: string) {
   if (storage === 'sessionStorage') {
     try {
       window.sessionStorage?.setItem(storageKey, preference)
-    } catch (e: unknown) {
-      // console.log(`Problem setting localStorage. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+    }
+    catch {
+      // Ignore sessionStorage write errors; storage may be blocked.
     }
     return
   }
 
   try {
     window.localStorage?.setItem(storageKey, preference)
-  } catch (e: unknown) {
-    // console.log(`Problem setting localStorage. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+  }
+  catch {
+    // Ignore localStorage write errors; storage may be blocked.
   }
 }

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -137,7 +137,11 @@ function setPreferenceToStorage(preference: string) {
       for (const key in cookieAttrs) {
         cookieString += `; ${key}=${cookieAttrs[key as keyof typeof cookieAttrs]}`
       }
-      window.document.cookie = cookieString
+      try {
+        window.document.cookie = cookieString
+      } catch (e: unknown) {
+        // console.log(`Problem setting cookie. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+      }
     }
     else {
       window.document.cookie = storageKey + '=' + preference
@@ -146,9 +150,17 @@ function setPreferenceToStorage(preference: string) {
   }
 
   if (storage === 'sessionStorage') {
-    window.sessionStorage?.setItem(storageKey, preference)
+    try {
+      window.sessionStorage?.setItem(storageKey, preference)
+    } catch (e: unknown) {
+      // console.log(`Problem setting localStorage. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+    }
     return
   }
 
-  window.localStorage?.setItem(storageKey, preference)
+  try {
+    window.localStorage?.setItem(storageKey, preference)
+  } catch (e: unknown) {
+    // console.log(`Problem setting localStorage. Browser may have disabled it (which they're allowed to do) but this means settings may not be persisted.`, e)
+  }
 }

--- a/src/script.js
+++ b/src/script.js
@@ -84,20 +84,23 @@ function getStorageValue(storageType, storageKey) {
     case 'localStorage':
       try {
         return window.localStorage.getItem(storageKey)
-      } catch (e) {
-        // console.log('Problem accessing localStorage. Browser may have disabled it.', e)
+      }
+      catch {
+        return null
       }
     case 'sessionStorage':
       try {
         return window.sessionStorage.getItem(storageKey)
-      } catch (e) {
-        // console.log('Problem accessing sessionStorage. Browser may have disabled it.', e)
+      }
+      catch {
+        return null
       }
     case 'cookie':
       try {
         return getCookie(storageKey)
-      } catch (e) {
-        // console.log('Problem accessing cookie storage. Browser may have disabled it.', e)
+      }
+      catch {
+        return null
       }
     default:
       return null

--- a/src/script.js
+++ b/src/script.js
@@ -82,11 +82,23 @@
 function getStorageValue(storageType, storageKey) {
   switch (storageType) {
     case 'localStorage':
-      return window.localStorage.getItem(storageKey)
+      try {
+        return window.localStorage.getItem(storageKey)
+      } catch (e) {
+        // console.log('Problem accessing localStorage. Browser may have disabled it.', e)
+      }
     case 'sessionStorage':
-      return window.sessionStorage.getItem(storageKey)
+      try {
+        return window.sessionStorage.getItem(storageKey)
+      } catch (e) {
+        // console.log('Problem accessing sessionStorage. Browser may have disabled it.', e)
+      }
     case 'cookie':
-      return getCookie(storageKey)
+      try {
+        return getCookie(storageKey)
+      } catch (e) {
+        // console.log('Problem accessing cookie storage. Browser may have disabled it.', e)
+      }
     default:
       return null
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #411 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Browsers can throw exceptions for cookies or storage (sessionstorage, localstorage) under certain circumstances:

* when cookies/storage are disabled
* when storage is full (technically possible because although `color-mode` uses a tiny amount of storage it could still be the tipping point if other site code uses storage)

So wrap usage of these volatile APIs in a try/catch, otherwise cookies/storage are effectively required to use a site.