### PR TITLE
chore: add npm bugs and homepage metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
   },
   "resolutions": {
     "h3": "1.15.11"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/nuxt-modules/color-mode/issues"
+  },
+  "homepage": "https://color-mode.nuxtjs.org"
 }


### PR DESCRIPTION
## Problem

`@nuxtjs/color-mode@4.0.1` exposes `repository` metadata but does not expose `bugs` or `homepage` metadata.

```sh
npm view @nuxtjs/color-mode bugs homepage
# (empty)
```

## Fix

Add the two missing fields:

```json
"bugs": { "url": "https://github.com/nuxt-modules/color-mode/issues" },
"homepage": "https://color-mode.nuxtjs.org"
```

Metadata-only change — no runtime behaviour is affected.