### PR TITLE
docs: add missing bugs and homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
   },
   "resolutions": {
     "h3": "1.15.11"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/nuxt-modules/color-mode/issues"
+  },
+  "homepage": "https://color-mode.nuxtjs.org"
 }


### PR DESCRIPTION
This PR fixes the following issue reported in charles-microbounties:
- Issue #1531: @nuxtjs/color-mode lacks npm bugs and homepage metadata

Changes:
- Added 'bugs': { 'url': 'https://github.com/nuxt-modules/color-mode/issues' }
- Added 'homepage': 'https://color-mode.nuxtjs.org'

Verified with publint.