### PR TITLE
docs: add missing bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/nuxt-modules/color-mode.git"
   },
   "license": "MIT",
+  "bugs": { "url": "https://github.com/nuxt-modules/color-mode/issues" },
   "packageManager": "pnpm@11.6.0",
   "contributors": [
     {


### PR DESCRIPTION
Added the missing `bugs` field to `package.json` to improve package discoverability and issue reporting. This is part of the micro-bounty initiative.