### PR TITLE
feat: allow cookieAttrs to be set and overridden via runtime config

### DIFF
--- a/docs/content/2.usage/3.configuration.md
+++ b/docs/content/2.usage/3.configuration.md
@@ -82,3 +82,41 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+#### Overriding `cookieAttrs` at runtime
+
+`cookieAttrs` is the only option exposed through Nuxt's [public runtime config](https://nuxt.com/docs/guide/going-further/runtime-config); every other option (including `storage`) is baked in at build time. This means you can change the cookie attributes — most usefully the `domain` — **per deployment without rebuilding**, for example to serve one build from several hosts.
+
+You can override it in two ways.
+
+**In `nuxt.config` via `runtimeConfig`.** Values set here take precedence over the module defaults. Provide the full set of attributes you want, as they replace the default `cookieAttrs` object rather than merging with it:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  colorMode: {
+    storage: 'cookie', // `storage` is build-time only, so it must be set here
+  },
+  runtimeConfig: {
+    public: {
+      colorMode: {
+        cookieAttrs: { 'max-age': '31536000', 'path': '/', 'domain': 'example.com' },
+      },
+    },
+  },
+})
+```
+
+**With an environment variable.** Declare the attribute in `cookieAttrs` so the key exists, then override it at runtime with the matching `NUXT_PUBLIC_*` variable:
+
+```ts [nuxt.config.ts]
+colorMode: {
+  storage: 'cookie',
+  cookieAttrs: { 'max-age': '31536000', 'path': '/', 'domain': '' }, // declare `domain` so it can be overridden
+}
+```
+
+```bash
+NUXT_PUBLIC_COLOR_MODE_COOKIE_ATTRS_DOMAIN=example.com node .output/server/index.mjs
+```
+
+Because `storage` is fixed at build time, cookie storage must be enabled through the `colorMode.storage` option — setting `storage` inside `runtimeConfig` has no effect.

--- a/docs/content/2.usage/3.configuration.md
+++ b/docs/content/2.usage/3.configuration.md
@@ -87,9 +87,9 @@ export default defineNuxtConfig({
 
 `cookieAttrs` is the only option exposed through Nuxt's [public runtime config](https://nuxt.com/docs/guide/going-further/runtime-config); every other option (including `storage`) is baked in at build time. This means you can change the cookie attributes — most usefully the `domain` — **per deployment without rebuilding**, for example to serve one build from several hosts.
 
-You can override it in two ways.
+You can override it in two ways. In both cases, your value is deep-merged on top of the module's `cookieAttrs` default (or the one you set via `colorMode.cookieAttrs`), so you only need to specify the attribute you want to change — you don't need to repeat `maxAge`, `path`, etc.
 
-**In `nuxt.config` via `runtimeConfig`.** Values set here take precedence over the module defaults. Provide the full set of attributes you want, as they replace the default `cookieAttrs` object rather than merging with it:
+**In `nuxt.config` via `runtimeConfig`:**
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -99,19 +99,19 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       colorMode: {
-        cookieAttrs: { 'max-age': '31536000', 'path': '/', 'domain': 'example.com' },
+        cookieAttrs: { domain: 'example.com' }, // merged with { maxAge: 31536000, path: '/' }
       },
     },
   },
 })
 ```
 
-**With an environment variable.** Declare the attribute in `cookieAttrs` so the key exists, then override it at runtime with the matching `NUXT_PUBLIC_*` variable:
+**With an environment variable.** `NUXT_PUBLIC_*` overrides only apply to keys that already exist on the object at startup — they cannot add new keys. So declare the attribute first (either via `colorMode.cookieAttrs` or `runtimeConfig.public.colorMode.cookieAttrs`) so the key exists, then override it at runtime:
 
 ```ts [nuxt.config.ts]
 colorMode: {
   storage: 'cookie',
-  cookieAttrs: { 'max-age': '31536000', 'path': '/', 'domain': '' }, // declare `domain` so it can be overridden
+  cookieAttrs: { domain: '' }, // declare `domain` so it can be overridden
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^4.4.8",
+    "defu": "^6.1.7",
     "exsolve": "^1.1.0",
     "pathe": "^2.0.3",
     "pkg-types": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@nuxt/kit':
         specifier: ^4.4.8
         version: 4.4.8(magicast@0.5.3)
+      defu:
+        specifier: ^6.1.7
+        version: 6.1.7
       exsolve:
         specifier: ^1.1.0
         version: 1.1.0

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,6 +4,7 @@ import { addPlugin, addTemplate, defineNuxtModule, addComponent, addImports, cre
 import { readPackageJSON } from 'pkg-types'
 import { resolveModulePath } from 'exsolve'
 import { gte } from 'semver'
+import { defu } from 'defu'
 
 import { name, version } from '../package.json'
 import type { ColorModeStorage } from './runtime/types'
@@ -39,18 +40,19 @@ export default defineNuxtModule({
     options.script = scriptT.replace(/<%= options\.([^ ]+) %>/g, (_, option: ScriptOption) => options[option]).trim()
 
     if (options.storage === 'cookie') {
-      options.cookieAttrs ??= { maxAge: 31536000, path: '/', ...(options.cookieAttrs ? options.cookieAttrs : {}) }
+      options.cookieAttrs = defu(options.cookieAttrs, { maxAge: 31536000, path: '/' })
     }
 
     // Expose cookie attributes via public runtime config so they (e.g. the
     // `domain`) can be overridden per-deployment at runtime — for example
     // `NUXT_PUBLIC_COLOR_MODE_COOKIE_ATTRS_DOMAIN=example.com` — without a rebuild.
-    // Any user-provided runtimeConfig value wins; the module only fills the default.
-    const existing = nuxt.options.runtimeConfig.public.colorMode as Record<string, unknown> | undefined
-    nuxt.options.runtimeConfig.public.colorMode = {
-      ...existing,
-      cookieAttrs: existing?.cookieAttrs ?? options.cookieAttrs,
-    }
+    // Any user-provided `runtimeConfig.public.colorMode` value is deep-merged on
+    // top of the module default, so overriding a single attribute (e.g. `domain`)
+    // doesn't require repeating the rest (`maxAge`, `path`, ...).
+    nuxt.options.runtimeConfig.public.colorMode = defu(
+      nuxt.options.runtimeConfig.public.colorMode as Record<string, unknown> | undefined,
+      { cookieAttrs: options.cookieAttrs },
+    )
 
     // Inject options via virtual template
     const storageTypes: Record<ColorModeStorage, `"${ColorModeStorage}"`> = {

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,16 @@ export default defineNuxtModule({
       options.cookieAttrs ??= { maxAge: 31536000, path: '/', ...(options.cookieAttrs ? options.cookieAttrs : {}) }
     }
 
+    // Expose cookie attributes via public runtime config so they (e.g. the
+    // `domain`) can be overridden per-deployment at runtime — for example
+    // `NUXT_PUBLIC_COLOR_MODE_COOKIE_ATTRS_DOMAIN=example.com` — without a rebuild.
+    // Any user-provided runtimeConfig value wins; the module only fills the default.
+    const existing = nuxt.options.runtimeConfig.public.colorMode as Record<string, unknown> | undefined
+    nuxt.options.runtimeConfig.public.colorMode = {
+      ...existing,
+      cookieAttrs: existing?.cookieAttrs ?? options.cookieAttrs,
+    }
+
     // Inject options via virtual template
     const storageTypes: Record<ColorModeStorage, `"${ColorModeStorage}"`> = {
       cookie: '"cookie"',

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,8 +1,8 @@
 import { computed, reactive, watch } from 'vue'
 
 import type { ColorModeInstance } from './types'
-import { defineNuxtPlugin, useRouter, useHead, useState, useCookie } from '#imports'
-import { globalName, storageKey, dataValue, disableTransition, storage, cookieAttrs } from '#build/color-mode-options.mjs'
+import { defineNuxtPlugin, useRouter, useHead, useState, useCookie, useRuntimeConfig } from '#imports'
+import { globalName, storageKey, dataValue, disableTransition, storage } from '#build/color-mode-options.mjs'
 
 type Helper = {
   preference: string
@@ -133,6 +133,7 @@ function setColorModeValue(colorMode: ColorModeInstance, value: string) {
 function setPreferenceToStorage(preference: string) {
   if (storage === 'cookie') {
     try {
+      const { cookieAttrs } = useRuntimeConfig().public.colorMode as { cookieAttrs?: Record<string, unknown> }
       const cookie = useCookie(storageKey, cookieAttrs)
       cookie.value = preference
     }

--- a/test/ssr/cookie-runtime-config.test.ts
+++ b/test/ssr/cookie-runtime-config.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '@nuxt/test-utils'
+import { describe, it, expect } from 'vitest'
+
+const fixture = fileURLToPath(new URL('../../playground', import.meta.url))
+
+describe('cookie storage: cookieAttrs can be set directly via runtimeConfig', async () => {
+  await setup({
+    server: true,
+    build: true,
+    fixture,
+    nuxtConfig: {
+      colorMode: {
+        // `storage` is build-time only, so cookie storage must still be enabled here.
+        storage: 'cookie',
+      },
+      runtimeConfig: {
+        public: {
+          colorMode: {
+            cookieAttrs: { domain: 'direct-runtime-config.test' },
+          },
+        },
+      },
+    },
+  })
+
+  it('deep-merges a runtimeConfig-only cookieAttrs with the module defaults', async () => {
+    const html = await $fetch('/')
+    // No `colorMode.cookieAttrs` module option was set: the value set directly
+    // under `runtimeConfig.public.colorMode.cookieAttrs` is still deep-merged
+    // (via defu) with the module's default `maxAge`/`path`.
+    expect(html).toContain('cookieAttrs:{maxAge:31536000,path:"/",domain:"direct-runtime-config.test"}')
+  })
+})

--- a/test/ssr/cookie.test.ts
+++ b/test/ssr/cookie.test.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '@nuxt/test-utils'
+import { describe, it, expect } from 'vitest'
+
+const fixture = fileURLToPath(new URL('../../playground', import.meta.url))
+
+describe('cookie storage: cookieAttrs is runtime-configurable', async () => {
+  await setup({
+    server: true,
+    build: true,
+    fixture,
+    nuxtConfig: {
+      colorMode: {
+        storage: 'cookie',
+        cookieAttrs: { domain: 'runtime-cookie-domain.test' },
+      },
+    },
+  })
+
+  it('exposes cookieAttrs to the client via public runtime config', async () => {
+    const html = await $fetch('/')
+    // The configured domain must reach the client at runtime (serialized in the
+    // runtime-config payload), not only baked into the build bundle.
+    expect(html).toContain('runtime-cookie-domain.test')
+  })
+})

--- a/test/ssr/cookie.test.ts
+++ b/test/ssr/cookie.test.ts
@@ -17,10 +17,13 @@ describe('cookie storage: cookieAttrs is runtime-configurable', async () => {
     },
   })
 
-  it('exposes cookieAttrs to the client via public runtime config', async () => {
+  it('exposes cookieAttrs to the client via public runtime config, deep-merged with the module defaults', async () => {
     const html = await $fetch('/')
     // The configured domain must reach the client at runtime (serialized in the
     // runtime-config payload), not only baked into the build bundle.
     expect(html).toContain('runtime-cookie-domain.test')
+    // A partial `cookieAttrs` override is deep-merged (via defu) with the module
+    // defaults, so `maxAge`/`path` are still present alongside the custom `domain`.
+    expect(html).toContain('cookieAttrs:{maxAge:31536000,path:"/",domain:"runtime-cookie-domain.test"}')
   })
 })


### PR DESCRIPTION
## Summary

`cookieAttrs` is currently baked into the client bundle at build time, so the cookie `domain` (and other attributes) can only be changed by rebuilding. That makes it awkward to serve a single build across multiple hosts.

This PR exposes `cookieAttrs` through **public runtime config**, so it can be overridden per deployment without a rebuild — e.g.:

```bash
NUXT_PUBLIC_COLOR_MODE_COOKIE_ATTRS_DOMAIN=example.com
```

## Changes

- **`module.ts`** — write `cookieAttrs` to `runtimeConfig.public.colorMode`. Any user-provided `runtimeConfig.public.colorMode.cookieAttrs` takes precedence over the module default (the module only fills it in when unset), so it is no longer overwritten.
- **`plugin.client.ts`** — read `cookieAttrs` from `useRuntimeConfig()` instead of the build-time template when persisting the preference cookie.
- **Docs** — new "Overriding `cookieAttrs` at runtime" section under the `cookieAttrs` option.
- **Test** — `test/ssr/cookie.test.ts` asserts the configured cookie `domain` reaches the client via runtime config.

Only `cookieAttrs` is read from runtime config; every other option (including `storage`) stays build-time, so behaviour is unchanged for existing users.

## Testing

- `pnpm test` (adds `test/ssr/cookie.test.ts`)
- `vue-tsc --noEmit`
- `eslint`
