### PR TITLE
fix: use useCookie option names for cookieAttrs (#432)

### DIFF
--- a/docs/content/2.usage/3.configuration.md
+++ b/docs/content/2.usage/3.configuration.md
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
     classSuffix: '',
     storage: 'localStorage', // or 'sessionStorage' or 'cookie'
     storageKey: 'nuxt-color-mode',
-    cookieAttrs: { 'max-age': '31536000', path: '/' }
+    cookieAttrs: { maxAge: 31536000, path: '/' }
   }
 })
 ```
@@ -62,7 +62,7 @@ Storage key name.
 ### `cookieAttrs`
 
 - Type: `object`
-- Default: `{ 'max-age': '31536000', path: '/' }`
+- Default: `{ maxAge: 31536000, path: '/' }`
 
 Attributes to set on the cookie when `storage` is set to `'cookie'`. By default, the cookie is set with a one-year max age and scoped to the root path.
 
@@ -74,10 +74,10 @@ export default defineNuxtConfig({
   colorMode: {
     storage: 'cookie',
     cookieAttrs: {
-      'max-age': '31536000',
-      'path': '/',
-      'SameSite': 'Lax',
-      'Secure': '',
+      maxAge: 31536000,
+      path: '/',
+      sameSite: 'lax',
+      secure: true,
     }
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,7 @@ export default defineNuxtModule({
     options.script = scriptT.replace(/<%= options\.([^ ]+) %>/g, (_, option: ScriptOption) => options[option]).trim()
 
     if (options.storage === 'cookie') {
-      options.cookieAttrs ??= { 'max-age': '31536000', 'path': '/', ...(options.cookieAttrs ? options.cookieAttrs : {}) }
+      options.cookieAttrs ??= { maxAge: 31536000, path: '/', ...(options.cookieAttrs ? options.cookieAttrs : {}) }
     }
 
     // Inject options via virtual template


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #432

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`cookieAttrs` is passed directly to Nuxt's `useCookie` composable. The documentation and default values used Set-Cookie attribute names (`'max-age'`, `'SameSite'`, `'Secure'`) instead of `useCookie` option names (`maxAge`, `sameSite`, `secure`), so those options were ignored by `cookie-es`.
This PR updates the docs examples and the module default `cookieAttrs` to use the correct camelCase option names.

### Test plan:
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Verified cookie `Expires` is set when using `maxAge` (not `Session`)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
